### PR TITLE
Add proxy server and update widget source URL

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "svgCode": "<!-- SVG code can be pasted here -->",
-  "sourceUrl": "",
+  "sourceUrl": "http://localhost:3000/v2/geodata/waveforecast/fairway",
   "refreshInterval": 0,
   "overallBackground": "#FFFFFF",
   "padding": 15,

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,20 @@
+# BarentsWatch Wave Forecast Proxy
+
+This lightweight Node.js server forwards widget requests to the BarentsWatch
+`/v2/geodata/waveforecast/fairway` endpoint. It appends the required token and
+returns the response with CORS headers so it can be called from the browser.
+
+## Usage
+
+1. Ensure you are running Node.js 18 or newer.
+2. Export your BarentsWatch token as an environment variable:
+   ```bash
+   export BARENTSWATCH_TOKEN=your_token_here
+   ```
+3. Start the proxy:
+   ```bash
+   node server.js
+   ```
+4. Point the widget's `sourceUrl` to `http://localhost:3000/v2/geodata/waveforecast/fairway`.
+
+The proxy listens on port `3000` by default. Use the `PORT` environment variable to change it.

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,0 +1,45 @@
+const http = require('http');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const TARGET = 'https://www.barentswatch.no/bwapi/v2/geodata/waveforecast/fairway';
+
+const server = http.createServer(async (req, res) => {
+  // Only handle GET requests to the waveforecast endpoint
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    return res.end('Method Not Allowed');
+  }
+
+  const incomingUrl = new URL(req.url, `http://${req.headers.host}`);
+  if (incomingUrl.pathname !== '/v2/geodata/waveforecast/fairway') {
+    res.statusCode = 404;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    return res.end('Not Found');
+  }
+
+  const targetUrl = TARGET + incomingUrl.search;
+
+  try {
+    const upstream = await fetch(targetUrl, {
+      headers: { Authorization: `Bearer ${process.env.BARENTSWATCH_TOKEN || ''}` }
+    });
+    const body = await upstream.text();
+
+    res.statusCode = upstream.status;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    const type = upstream.headers.get('content-type');
+    if (type) res.setHeader('Content-Type', type);
+    res.end(body);
+  } catch (err) {
+    res.statusCode = 500;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: err.message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Proxy listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a minimal Node.js proxy server that forwards requests to BarentsWatch wave forecast API with token and CORS headers
- default widget `sourceUrl` now points to the local proxy endpoint
- document how to run the proxy

## Testing
- `npm test` *(fails: could not read package.json)*
- `node proxy/server.js` (server started and listened on port 3000)


------
https://chatgpt.com/codex/tasks/task_e_68a6040783408330ab786b38f8b3a44b