### PR TITLE
Allow widget to use API token for SVG requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Add layers
 
+## API Tokens
+
+The widget can attach an authentication token when requesting SVG content. For production deployments, supply tokens through a secure configuration mechanism or a proxy service so that secrets are not exposed in client-side code.
+

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "svgCode": "<!-- SVG code can be pasted here -->",
   "sourceUrl": "",
+  "apiToken": "",
   "refreshInterval": 0,
   "overallBackground": "#FFFFFF",
   "padding": 15,

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -4,6 +4,7 @@ export interface Config {
   svgCode: string
 
   sourceUrl?: string
+  apiToken?: string
   refreshInterval?: number
 
   overallBackground: string

--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -61,12 +61,12 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
   }
 
   fetchSvgFromUrl = async (): Promise<void> => {
-    const { sourceUrl } = this.props.config
+    const { sourceUrl, apiToken } = this.props.config
     if (!sourceUrl) return
     try {
-      const res = await fetch(sourceUrl, {
-        headers: { Accept: 'image/svg+xml,application/json,text/plain,*/*' }
-      })
+      const headers: Record<string, string> = { Accept: 'image/svg+xml,application/json,text/plain,*/*' }
+      if (apiToken) headers.Authorization = `Bearer ${apiToken}`
+      const res = await fetch(sourceUrl, { headers })
       if (!res.ok) {
         this.setState({ error: `Network error: ${res.status}` })
         return

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -56,6 +56,14 @@ export default class Setting extends React.PureComponent<AllWidgetSettingProps<I
               onChange={(e) => { this.onConfigChange('sourceUrl', e.target.value) }}
             />
           </SettingRow>
+          <SettingRow label={intl.formatMessage({ id: 'apiToken', defaultMessage: defaultMessages.apiToken })}>
+            <input
+              type="text"
+              className="jimu-input"
+              value={config.apiToken || ''}
+              onChange={(e) => { this.onConfigChange('apiToken', e.target.value) }}
+            />
+          </SettingRow>
           <SettingRow label={intl.formatMessage({ id: 'refreshInterval', defaultMessage: defaultMessages.refreshInterval })}>
             <NumericInput
               style={narrowNumericBoxStyle}

--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -3,6 +3,7 @@ export default {
     svgCodePlaceholder: 'Paste SVG code here',
     dataSource: 'Data Source',
     sourceUrl: 'Source URL',
+    apiToken: 'API Token',
     refreshInterval: 'Refresh Interval (min)',
     generalStyling: 'General Styling',
     overallBackground: 'Overall Background',


### PR DESCRIPTION
## Summary
- add optional `apiToken` to widget configuration and settings
- allow runtime widget to attach `Authorization` header when token supplied
- document secure provisioning of tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a603ff7ad083309e29c86cd760d3f1