### PR TITLE
Handle unauthorized token responses

### DIFF
--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -67,6 +67,10 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
       const headers: Record<string, string> = { Accept: 'image/svg+xml,application/json,text/plain,*/*' }
       if (apiToken) headers.Authorization = `Bearer ${apiToken}`
       const res = await fetch(sourceUrl, { headers })
+      if (res.status === 401) {
+        this.setState({ error: 'Invalid or missing token' })
+        return
+      }
       if (!res.ok) {
         this.setState({ error: `Network error: ${res.status}` })
         return


### PR DESCRIPTION
## Summary
- support supplying an API token through widget settings and config
- send token in Authorization header for fetch requests
- show an "Invalid or missing token" message on 401 responses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a612461c388330a57cb685f504fc87